### PR TITLE
Create basic Next.js auth pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# legaleo-test
+# Legaleo
+
+This project provides a basic Next.js setup with pages for login, signup, and reset password using **NextAuth.js**.
+
+## Development
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+These commands require internet access to download packages.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  reactStrictMode: true,
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "legaleo",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "next-auth": "4.20.1"
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,9 @@
+import { SessionProvider } from 'next-auth/react';
+
+export default function App({ Component, pageProps: { session, ...pageProps } }) {
+  return (
+    <SessionProvider session={session}>
+      <Component {...pageProps} />
+    </SessionProvider>
+  );
+}

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -1,0 +1,24 @@
+import NextAuth from 'next-auth';
+import CredentialsProvider from 'next-auth/providers/credentials';
+
+export default NextAuth({
+  providers: [
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'email' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        // Replace this with your own logic to look up the user
+        if (credentials.email && credentials.password) {
+          return { id: 1, name: credentials.email };
+        }
+        return null;
+      },
+    }),
+  ],
+  session: {
+    strategy: 'jwt',
+  },
+});

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,12 @@
+import Link from 'next/link';
+
+export default function Home() {
+  return (
+    <div>
+      <h1>Welcome to legaleo</h1>
+      <p><Link href="/login">Login</Link></p>
+      <p><Link href="/signup">Sign up</Link></p>
+      <p><Link href="/reset-password">Reset Password</Link></p>
+    </div>
+  );
+}

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,0 +1,33 @@
+import { getCsrfToken, signIn } from 'next-auth/react';
+import { useState } from 'react';
+
+export default function Login({ csrfToken }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await signIn('credentials', { email, password });
+  };
+
+  return (
+    <form method="post" onSubmit={handleSubmit}>
+      <input name="csrfToken" type="hidden" defaultValue={csrfToken} />
+      <label>
+        Email
+        <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+      </label>
+      <label>
+        Password
+        <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+      </label>
+      <button type="submit">Login</button>
+    </form>
+  );
+}
+
+Login.getInitialProps = async (context) => {
+  return {
+    csrfToken: await getCsrfToken(context),
+  };
+};

--- a/pages/reset-password.js
+++ b/pages/reset-password.js
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+
+export default function ResetPassword() {
+  const [email, setEmail] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    // Call your reset password endpoint here
+    console.log('Reset password', { email });
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label>
+        Email
+        <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+      </label>
+      <button type="submit">Reset Password</button>
+    </form>
+  );
+}

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+export default function SignUp() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    // Call your sign-up endpoint here
+    console.log('Sign up', { email, password });
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label>
+        Email
+        <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+      </label>
+      <label>
+        Password
+        <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+      </label>
+      <button type="submit">Sign Up</button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- initialize Next.js project structure
- add login, signup and reset password pages
- wire up NextAuth with credentials provider
- document local development

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e98819a288327b4760358758033fa