### PR TITLE
Add contract generation workflow with Claude template attachment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.next/
+.env

--- a/app/contract/README.md
+++ b/app/contract/README.md
@@ -1,0 +1,3 @@
+# Modèle de contrat
+
+Placez ici le fichier `modele_de_contrat.pdf` qui sera utilisé comme pièce jointe lors de la génération des contrats.

--- a/pages/api/contracts/generate.js
+++ b/pages/api/contracts/generate.js
@@ -1,0 +1,126 @@
+import fs from 'fs';
+import path from 'path';
+
+const CLAUDE_API_URL = 'https://api.anthropic.com/v1/messages';
+
+function buildPrompt(qaPairs) {
+  const header = `Tu es un assistant juridique francophone spécialisé dans la rédaction de contrats.
+Ton objectif est de produire un contrat complet et cohérent en t'appuyant sur les informations fournies et sur le modèle joint.
+
+Consignes à respecter :
+1. Utilise le fichier \"modele_de_contrat.pdf\" fourni en pièce jointe comme squelette formel du document sans le retranscrire intégralement.
+2. Adapte chaque section du contrat en fonction des réponses aux questions ci-dessous, en respectant l'ordre et la structure du modèle.
+3. Ne renvoie que le texte final du contrat, sans instructions supplémentaires.
+4. Rédige l'intégralité du contrat en français juridique clair.
+5. Vérifie la cohérence de l'ensemble et signale les informations manquantes par des espaces réservés clairement identifiés (ex. \"[Information manquante]\").`;
+
+  const formattedPairs = qaPairs
+    .map((pair, index) => {
+      return `### Question ${index + 1}
+Question : ${pair.question.trim()}
+Réponse : ${pair.answer.trim()}`;
+    })
+    .join('\n\n');
+
+  return `${header}\n\nInformations recueillies :\n${formattedPairs}`;
+}
+
+async function sendToClaude({ prompt, encodedTemplate, model }) {
+  const body = {
+    model: model || process.env.CLAUDE_MODEL || 'claude-3-5-sonnet-20240620',
+    max_tokens: 4096,
+    temperature: 0.2,
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: prompt,
+          },
+          {
+            type: 'document',
+            title: 'modele_de_contrat.pdf',
+            source: {
+              type: 'base64',
+              media_type: 'application/pdf',
+              data: encodedTemplate,
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  const response = await fetch(CLAUDE_API_URL, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': process.env.CLAUDE_API_KEY ?? '',
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Erreur Claude API (${response.status}): ${errorText}`);
+  }
+
+  return response.json();
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Méthode non autorisée' });
+  }
+
+  const { qaPairs, model } = req.body ?? {};
+
+  if (!Array.isArray(qaPairs) || qaPairs.length === 0) {
+    return res.status(400).json({ error: 'Veuillez fournir au moins une question et réponse.' });
+  }
+
+  const sanitizedPairs = [];
+  for (const pair of qaPairs) {
+    if (!pair || typeof pair.question !== 'string' || typeof pair.answer !== 'string') {
+      return res.status(400).json({ error: 'Format des questions/réponses invalide.' });
+    }
+
+    const question = pair.question.trim();
+    const answer = pair.answer.trim();
+
+    if (!question || !answer) {
+      return res.status(400).json({ error: 'Chaque question et réponse doit être renseignée.' });
+    }
+
+    sanitizedPairs.push({ question, answer });
+  }
+
+  const templatePath = path.join(process.cwd(), 'app', 'contract', 'modele_de_contrat.pdf');
+
+  let templateBuffer;
+  try {
+    templateBuffer = await fs.promises.readFile(templatePath);
+  } catch (error) {
+    return res.status(500).json({
+      error: "Impossible de lire le modèle de contrat. Assurez-vous que 'modele_de_contrat.pdf' est présent dans /app/contract.",
+      details: error.message,
+    });
+  }
+
+  const encodedTemplate = templateBuffer.toString('base64');
+  const prompt = buildPrompt(sanitizedPairs);
+
+  if (!process.env.CLAUDE_API_KEY) {
+    return res.status(500).json({ error: 'La clé API Claude est manquante (variable CLAUDE_API_KEY).' });
+  }
+
+  try {
+    const claudeResponse = await sendToClaude({ prompt, encodedTemplate, model });
+    return res.status(200).json({ success: true, claudeResponse });
+  } catch (error) {
+    return res.status(500).json({ error: error.message });
+  }
+}

--- a/pages/generate-contract.js
+++ b/pages/generate-contract.js
@@ -1,0 +1,143 @@
+import { useState } from 'react';
+
+const emptyPair = { question: '', answer: '' };
+
+export default function GenerateContract() {
+  const [qaPairs, setQaPairs] = useState([{ ...emptyPair }]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [result, setResult] = useState(null);
+  const [contractText, setContractText] = useState('');
+
+  const updatePair = (index, field, value) => {
+    setQaPairs((prev) => {
+      const next = [...prev];
+      next[index] = { ...next[index], [field]: value };
+      return next;
+    });
+  };
+
+  const addPair = () => {
+    setQaPairs((prev) => [...prev, { ...emptyPair }]);
+  };
+
+  const removePair = (index) => {
+    setQaPairs((prev) => prev.filter((_, idx) => idx !== index));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setLoading(true);
+    setError('');
+    setResult(null);
+    setContractText('');
+
+    try {
+      const response = await fetch('/api/contracts/generate', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ qaPairs }),
+      });
+
+      const payload = await response.json();
+
+      if (!response.ok) {
+        throw new Error(payload.error || 'Erreur inconnue.');
+      }
+
+      setResult(payload.claudeResponse);
+      const textSegments = Array.isArray(payload?.claudeResponse?.content)
+        ? payload.claudeResponse.content
+            .filter((item) => item.type === 'text' && typeof item.text === 'string')
+            .map((item) => item.text)
+            .join('\n\n')
+        : '';
+      setContractText(textSegments);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <h1>Génération de contrat</h1>
+      <p>
+        Renseignez les questions et les réponses qui permettront de personnaliser le contrat.
+        Le modèle de contrat stocké dans <code>/app/contract/modele_de_contrat.pdf</code> sera envoyé en pièce jointe au prompt
+        Claude.
+      </p>
+      <form onSubmit={handleSubmit}>
+        {qaPairs.map((pair, index) => (
+          <fieldset key={index} style={{ marginBottom: '1rem' }}>
+            <legend>Question {index + 1}</legend>
+            <label style={{ display: 'block', marginBottom: '0.5rem' }}>
+              Question
+              <textarea
+                value={pair.question}
+                onChange={(event) => updatePair(index, 'question', event.target.value)}
+                rows={2}
+                style={{ width: '100%', marginTop: '0.25rem' }}
+                required
+              />
+            </label>
+            <label style={{ display: 'block', marginBottom: '0.5rem' }}>
+              Réponse
+              <textarea
+                value={pair.answer}
+                onChange={(event) => updatePair(index, 'answer', event.target.value)}
+                rows={3}
+                style={{ width: '100%', marginTop: '0.25rem' }}
+                required
+              />
+            </label>
+            {qaPairs.length > 1 && (
+              <button type="button" onClick={() => removePair(index)}>
+                Supprimer cette question
+              </button>
+            )}
+          </fieldset>
+        ))}
+        <button type="button" onClick={addPair} disabled={loading}>
+          Ajouter une question
+        </button>
+        <div style={{ marginTop: '1rem' }}>
+          <button type="submit" disabled={loading}>
+            {loading ? 'Génération en cours...' : 'Générer le contrat'}
+          </button>
+        </div>
+      </form>
+
+      {error && (
+        <p style={{ color: 'red', marginTop: '1rem' }}>
+          Erreur : {error}
+        </p>
+      )}
+
+      {result && (
+        <section style={{ marginTop: '2rem' }}>
+          <h2>Réponse de Claude</h2>
+          {contractText && (
+            <article
+              style={{
+                backgroundColor: '#ffffff',
+                border: '1px solid #e0e0e0',
+                padding: '1rem',
+                marginBottom: '1.5rem',
+                whiteSpace: 'pre-wrap',
+              }}
+            >
+              {contractText}
+            </article>
+          )}
+          <pre style={{ whiteSpace: 'pre-wrap', backgroundColor: '#f3f3f3', padding: '1rem' }}>
+            {JSON.stringify(result, null, 2)}
+          </pre>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -7,6 +7,7 @@ export default function Home() {
       <p><Link href="/login">Login</Link></p>
       <p><Link href="/signup">Sign up</Link></p>
       <p><Link href="/reset-password">Reset Password</Link></p>
+      <p><Link href="/generate-contract">Générer un contrat</Link></p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add an API route to build a refined prompt for Claude and attach the contract template PDF when generating agreements
- introduce a contract generation UI to collect question/answer pairs and submit them to the Claude-backed endpoint
- document the expected template location and ignore environment-specific directories

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911d7c1c37c832786bc0bd8749eb0ee)