### PR TITLE
Add contract template attachment for Claude generation

### DIFF
--- a/app/contract/modele_de_contrat.pdf
+++ b/app/contract/modele_de_contrat.pdf
@@ -1,0 +1,66 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 823 >>
+stream
+BT
+/F1 14 Tf
+72 800 Td
+(Modele de contrat de franchise - gabarit) Tj
+0 -24 Td
+(Renseigner chaque clause ci-dessous en vous appuyant sur le contexte.) Tj
+0 -36 Td
+(1. Parties au contrat :) Tj
+0 -20 Td
+(2. Objet de la franchise :) Tj
+0 -20 Td
+(3. Duree et renouvellement :) Tj
+0 -20 Td
+(4. Redevances et conditions financieres :) Tj
+0 -20 Td
+(5. Accompagnement et obligations du franchiseur :) Tj
+0 -20 Td
+(6. Obligations du franchise :) Tj
+0 -20 Td
+(7. Exclusivite territoriale :) Tj
+0 -20 Td
+(8. Propriete intellectuelle :) Tj
+0 -20 Td
+(9. Confidentialite et protection des donnees :) Tj
+0 -20 Td
+(10. Formation et assistance continue :) Tj
+0 -20 Td
+(11. Conditions de resiliation :) Tj
+0 -20 Td
+(12. Non-concurrence et non-sollicitation :) Tj
+0 -20 Td
+(13. Mediation et tribunal competent :) Tj
+0 -24 Td
+(Annexes :) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000001114 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+1184
+%%EOF

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -12,19 +12,19 @@ export function buildPrompt(items: QA[]): string {
     })
     .join("\n\n");
 
-  return `Tu es un avocat-rédacteur. Rédige un contrat de franchise complet, précis, en français contemporain, avec clauses standard et adaptées au contexte transmis.
+  return `Tu es un·e avocat·e-rédacteur·rice spécialisé·e en franchise. À partir du modèle PDF joint « modele_de_contrat.pdf », rédige un contrat de franchise complet en français contemporain en personnalisant chaque section du modèle avec les informations utiles du contexte.
+
+Instructions générales :
+- Utilise la structure, l'ordre des clauses et les intitulés proposés dans le modèle PDF joint sans le retranscrire mot pour mot.
+- Complète chaque clause avec les données contextuelles pertinentes. Si une information manque, insère clairement la mention "[à compléter]" et ne crée aucune donnée fictive.
+- Adopte un ton strictement professionnel et conforme au droit français applicable aux contrats de franchise (obligations précontractuelles, conformité INPI, RGPD, etc.).
+- Ajoute, si nécessaire, des clauses usuelles complémentaires lorsqu'elles s'intègrent naturellement dans la structure du modèle.
+- Ne retranscris pas intégralement le contenu du modèle PDF : contente-toi de le suivre comme guide de mise en forme et d'organisation.
 
 Contexte fourni :
 ${formattedContext}
 
-Contraintes d'écriture :
-- Ton strictement professionnel.
-- Ne pas inventer de données manquantes : indiquer explicitement "[à compléter]".
-- Adapter le contrat au cadre juridique français des réseaux de franchise.
-
-Structure attendue :
-- Un contrat avec titres numérotés, définitions, obligations, redevances, exclusivité territoriale, propriété intellectuelle, formation, manuel opératoire, conformité INPI, durée, résiliation, pénalités, confidentialité, RGPD, non-concurrence, médiation/tribunal compétent, annexes.
-- Ajouter toute clause usuelle pertinente pour un contrat de franchise complet en France.
-
-Génère uniquement le texte du contrat.`;
+Résultat attendu :
+- Un contrat finalisé prêt à être remis à un futur franchisé, avec des titres numérotés, définitions, obligations, redevances, exclusivité territoriale, propriété intellectuelle, formation, accompagnement, conformité réglementaire, modalités de résiliation, pénalités, clauses de confidentialité et RGPD, non-concurrence, règlement des litiges et annexes.
+- Le texte du contrat uniquement, sans instructions supplémentaires ni explications hors contrat.`;
 }


### PR DESCRIPTION
## Summary
- attach the franchise contract template PDF to Claude API requests so the model can rely on the reference structure
- refine the generated prompt to reference the PDF, contextual data, and professional drafting constraints
- add the franchise contract template PDF asset to the repository

## Testing
- npm run lint *(fails: command prompts for interactive configuration)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911de08da088327beba4a296c89c059)